### PR TITLE
Support for Redis Cache.

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,12 +1,21 @@
 version: '3.4'
 
 services:
+    cachedb:
+        container_name: cachedb
+        restart: always
+        ports:
+            - "6379:6379"
+
     realestateagentsapi:
         container_name: realestateagentsapi
-        restart: on-failure  
+        depends_on:
+            - cachedb
+        restart: on-failure
         environment:
             - ASPNETCORE_ENVIRONMENT=Development
             - DOTNET_RUNNING_IN_CONTAINER=true # Might be redundant since most images have this predefined
+            - "ConnectionStrings:Redis=cachedb:6379"      #override the connection string from appSettings: point to the redis container
         volumes:
             - ${HOME}/.microsoft/usersecrets/:/root/.microsoft/usersecrets
             - ${HOME}/.aspnet/https/:/root/.aspnet/https/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 version: '3.4'
 
 services:
+    cachedb:
+        image: redis
+    
     realestateagentsapi:
         image: ${DOCKER_REGISTRY-}realestateagentswebapi
         build:

--- a/src/RealEstateAgents/RealEstateAgents.Application/RealEstateAgents.Application.csproj
+++ b/src/RealEstateAgents/RealEstateAgents.Application/RealEstateAgents.Application.csproj
@@ -8,9 +8,9 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="RestEase" Version="1.5.0" />
   </ItemGroup>

--- a/src/RealEstateAgents/RealEstateAgents.Infrastructure.Shared/RealEstateAgents.Infrastructure.Shared.csproj
+++ b/src/RealEstateAgents/RealEstateAgents.Infrastructure.Shared/RealEstateAgents.Infrastructure.Shared.csproj
@@ -16,9 +16,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="9.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Redis" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="3.1.9" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.9" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
     <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="Scrutor.AspNetCore" Version="1.0.0" />
   </ItemGroup>

--- a/src/RealEstateAgents/RealEstateAgents.Infrastructure.Shared/ServiceRegistration.cs
+++ b/src/RealEstateAgents/RealEstateAgents.Infrastructure.Shared/ServiceRegistration.cs
@@ -28,9 +28,10 @@ namespace RealEstateAgents.Infrastructure.Shared
             services.Configure<CacheConfiguration>(config.GetSection("CacheConfiguration"));
 
             services.AddDistributedMemoryCache();
-            services.AddDistributedRedisCache(options =>
+            services.AddStackExchangeRedisCache(options =>
             {
                 options.Configuration = config.GetConnectionString("Redis");
+                options.InstanceName = "Redis";
             });
 
             services.AddTransient<ICacheService, CacheService>();

--- a/src/RealEstateAgents/RealEstateAgents.Infrastructure.Shared/Services/AgentService/Helpers/PropertyDataHelperCacheDecorator.cs
+++ b/src/RealEstateAgents/RealEstateAgents.Infrastructure.Shared/Services/AgentService/Helpers/PropertyDataHelperCacheDecorator.cs
@@ -20,7 +20,7 @@ namespace RealEstateAgents.Infrastructure.Shared.Services.AgentService.Helpers
 
         public async Task<List<PropertyDto>> FetchAllProperties(string typeOfSearch, string searchQuery)
         {
-            var cacheKey = $"{typeOfSearch}-{searchQuery}";
+            var cacheKey = $"{typeOfSearch}{searchQuery}";
             var cachedProperties = await _cache
                 .Get(cacheKey, async () => await _propertyDataHelper.FetchAllProperties(typeOfSearch, searchQuery));
 

--- a/src/RealEstateAgents/RealEstateAgents.WebApi/RealEstateAgents.WebApi.csproj
+++ b/src/RealEstateAgents/RealEstateAgents.WebApi/RealEstateAgents.WebApi.csproj
@@ -18,12 +18,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.9">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.4" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="5.6.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.6.3" />
@@ -32,9 +32,9 @@
     <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="5.5.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.9" />
+    <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="5.6.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/RealEstateAgents/RealEstateAgents.WebApi/appsettings.json
+++ b/src/RealEstateAgents/RealEstateAgents.WebApi/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "Redis": "localhost::6379"
+    "Redis": "localhost:6379"
   },
   "Serilog": {
     "Using": [],


### PR DESCRIPTION
Change Nuget from <Microsoft.Extensions.Caching.Redis> to <Microsoft.Extensions.Caching.StackExchangeRedis>.
Update docker-compose to spin up a Redis container as well.
Hint: Change the CacheTechnology in The Cache Service to use Redis over
in-memory cachin.

closes #6 